### PR TITLE
Fixes testBasicUsageWithLongKey test

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -116,7 +116,7 @@ abstract class CachePoolTest extends TestCase
 
         $pool = $this->createCachePool();
 
-        $key = str_repeat('a', 300);
+        $key = str_repeat('a', 250);
 
         $item = $pool->getItem($key);
         $this->assertFalse($item->isHit());


### PR DESCRIPTION
The max key length of a key in memcache is 250 https://github.com/memcached/memcached/blob/master/memcached.h#L56